### PR TITLE
Issue/fix trailing spaces in email

### DIFF
--- a/app/controllers/runners_controller.rb
+++ b/app/controllers/runners_controller.rb
@@ -25,6 +25,7 @@ class RunnersController < ApplicationController
   # POST /runners.json
   def create
     @runner = Runner.new(runner_params)
+    @runner.email.strip!  # When you cut'n'paste in emails, they can come it with a space at the end!
 
     respond_to do |format|
       if @runner.save

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -5,7 +5,7 @@ class SessionsController < ApplicationController
   end
 
   def create
-    runner = Runner.find_by(email: params[:session][:email].downcase.strip)
+    runner = Runner.find_by(email: params[:session][:email].downcase)
     if runner && runner.authenticate(params[:session][:password])
       # Log the user in and redirect to the user's show page
       log_in runner

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -5,7 +5,7 @@ class SessionsController < ApplicationController
   end
 
   def create
-    runner = Runner.find_by(email: params[:session][:email].downcase)
+    runner = Runner.find_by(email: params[:session][:email].downcase.strip)
     if runner && runner.authenticate(params[:session][:password])
       # Log the user in and redirect to the user's show page
       log_in runner

--- a/db/migrate/20150616102730_fix_emails_with_trailing_spaces.rb
+++ b/db/migrate/20150616102730_fix_emails_with_trailing_spaces.rb
@@ -1,0 +1,8 @@
+class FixEmailsWithTrailingSpaces < ActiveRecord::Migration
+  def change
+  	Runner.find_each do | runner |
+  		runner.email.strip!
+  		runner.save!
+  	end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150613014112) do
+ActiveRecord::Schema.define(version: 20150616102730) do
 
   create_table "groups", force: :cascade do |t|
     t.string   "name"


### PR DESCRIPTION
@Logan-K remind me to walk you through this commit.   Really happy with the though process on dealing with email addresses that look like "dep4b@yahoo.com ".   See the trailing space?  My first thought was to fix it by just adding a `.strip` to the end to deal with it.  But I realized, that if I fixed the underlying data, but cleaning up the existing data, and adding some validation when creating runners, that I could then remove the `.strip`.   When I see lots of string null or strip commands, that is a _code smell_.
